### PR TITLE
Removed some unneeded boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ git clone https://github.com/larshesel/vmq_elixir_plugin
 $ cd vmq_elixir_plugin
 $ mix deps.get
 $ mix compile
-$ vmq-admin plugin enable --name  vmq_elixir_plugin --path `pwd`/_build/dev/
+$ vmq-admin plugin enable --name vmq_elixir_plugin --path `pwd`/_build/dev/
 Done
 ```
 

--- a/lib/vmq_elixir_plugin.ex
+++ b/lib/vmq_elixir_plugin.ex
@@ -1,8 +1,4 @@
 defmodule VmqElixirPlugin do
-  use Application
-  require Logger
-
-
   @moduledoc """
   This file demonstrates the hooks you typically want to use
   if your plugin deals with Authentication or Authorization.
@@ -17,23 +13,6 @@ defmodule VmqElixirPlugin do
   IMPORTANT:
    these hook functions run in the session context
   """
-
-  @doc """
-  Application start function.
-  """
-  def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
-    children = [
-      # Define workers and child supervisors to be supervised
-      # worker(VmqElixirPlugin.Worker, [arg1, arg2, arg3])
-    ]
-
-    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
-    # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: VmqElixirPlugin.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
 
   @doc """
   Hook callback function handling authentication when registering.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule VmqElixirPlugin.Mixfile do
   def project do
     [app: :vmq_elixir_plugin,
      version: "0.0.2",
-     elixir: "== 1.1.1",
+     elixir: "~> 1.2.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps]
@@ -15,7 +15,6 @@ defmodule VmqElixirPlugin.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [applications: [:elixir],
-     mod: {VmqElixirPlugin, []},
      env: [vmq_plugin_hooks]]
   end
 


### PR DESCRIPTION
- Removed the Application behaviour
- Removed the `start/2` function, it started an empty supervisor
- Removed Logger, it cannot be used with the Lager version used by VerneMQ
- Removed whitespace in the Readme
